### PR TITLE
Convert DIRECTORY_SEPARATOR to / in Router

### DIFF
--- a/src/Mlaphp/Router.php
+++ b/src/Mlaphp/Router.php
@@ -58,6 +58,7 @@ class Router
     public function __construct($pages_dir = null)
     {
         if ($pages_dir) {
+            $pages_dir = str_replace(DIRECTORY_SEPARATOR, '/', $pages_dir);
             $this->pages_dir = rtrim($pages_dir, '/');
         }
     }


### PR DESCRIPTION
On Windows, `DIRECTORY_SEPARATOR` is `\`, which is is not compatible with URLs.
However, PHP is perfectly content to allow `/` as the user-supplied directory
separator. So convert `$pages_dir` to always use `/` in the constructor.

Closes #1.

I haven't actually tested this on Windows as I don't currently have a Windows install of PHP to work with. But I see no reason why it shouldn't work. Unfortunately, it's difficult if not impossible to write a unit test for this, as `DIRECTORY_SEPARATOR` isn't controllable.
