### PR TITLE
Fix magic method access of post

### DIFF
--- a/src/Mlaphp/Request.php
+++ b/src/Mlaphp/Request.php
@@ -44,6 +44,13 @@ class Request
     public $get = array();
 
     /**
+     * A copy of $_POST.
+     *
+     * @var array
+     */
+    public $post = array();
+
+    /**
      * A copy of $_REQUEST.
      *
      * @var array
@@ -75,7 +82,7 @@ class Request
 
     /**
      * Constructor.
-     * 
+     *
      * @param array $globals A reference to $GLOBALS.
      */
     public function __construct(&$globals)
@@ -139,7 +146,7 @@ class Request
         if (isset($this->globals['_SESSION'])) {
             $this->session = &$this->globals['_SESSION'];
         }
-        
+
         return isset($this->session);
     }
 


### PR DESCRIPTION
See https://github.com/mlaphp/mlaphp/issues/4

When accessing the post variable, I get a warning regarding accessing
the variable via magic method because the referenced field is not found
in the subject class. This is due to the variable being created in the
constructor and is not explicitly created like all the other
superglobals.
- Create public variable $post
